### PR TITLE
Add check for unbound user object before kafka producer step.

### DIFF
--- a/apigateway/services.py
+++ b/apigateway/services.py
@@ -1408,10 +1408,15 @@ class KafkaProducerService(GatewayService):
         @app.after_request
         def _after_request_hook(response: Response):
             if self._producer is not None:
+                try:
+                    real_user = current_user._get_current_object()
+                except:
+                    current_app.logger.exception("Unable to collect real user. Most likely due to unbound session.")
+                    return response
                 self._producer.send(
                     self.get_service_config("REQUEST_TOPIC"),
                     {
-                        "user_id": current_user.get_id(),
+                        "user_id": real_user.get_id(),
                         "client_id": (
                             current_token.client_id
                             if current_token and hasattr(current_token, "client")

--- a/apigateway/services.py
+++ b/apigateway/services.py
@@ -1410,7 +1410,7 @@ class KafkaProducerService(GatewayService):
             if self._producer is not None:
                 try:
                     real_user = current_user._get_current_object()
-                except:
+                except RuntimeError:
                     current_app.logger.exception("Unable to collect real user. Most likely due to unbound session.")
                     return response
                 self._producer.send(


### PR DESCRIPTION
When a user logs in, the `current_user` object becomes unbound from it's session, resulting in an error when the producer attempts to access the object for the purpose of generating the kafka message. This PR adds a check to make sure the user object is still bound.