### PR TITLE
`verify_url` Hotfix

### DIFF
--- a/apigateway/utils.py
+++ b/apigateway/utils.py
@@ -253,8 +253,8 @@ class ProxyView(View):
         Returns:
             str: The URL of the remote server.
         """
-        verify_url_regex = re.compile(r"^([12]\d\d\d[A-Za-z&\.]{5}[A-Za-z0-9\.]{9}[A-Z\.]/verify_url\:http[s]?\://.*)")
-
+        verify_url_regex = re.compile(r"([12]\d\d\d[A-Za-z&\.]{5}[A-Za-z0-9\.]{9}[A-Z\.]/verify_url\:)(http[s]?\://)(.*)")
+        
         path = request.full_path.replace(self._deploy_path, "", 1)
         path = path[1:] if path.startswith("/") else path
         #This block exists because of an incompatibility between urlparse.urljoin and urllib.parse.urljoin

--- a/apigateway/utils.py
+++ b/apigateway/utils.py
@@ -252,10 +252,13 @@ class ProxyView(View):
         Returns:
             str: The URL of the remote server.
         """
+        verify_url_regex = re.compile(r"^([12]\d\d\d[A-Za-z&\.]{5}[A-Za-z0-9\.]{9}[A-Z\.]/verify_url\:http[s]?\://.*)")
+
         path = request.full_path.replace(self._deploy_path, "", 1)
         path = path[1:] if path.startswith("/") else path
-        verify_url_regex = re.compile(r"^([12]\d\d\d[A-Za-z&\.]{5}[A-Za-z0-9\.]{9}[A-Z\.]/verify_url\:http[s]?\://.*)")
+        
         if verify_url_regex.match(path): return str(self._remote_base_url)+"/"+str(path)
+        
         return urljoin(self._remote_base_url, path)
 
 

--- a/apigateway/utils.py
+++ b/apigateway/utils.py
@@ -257,7 +257,8 @@ class ProxyView(View):
 
         path = request.full_path.replace(self._deploy_path, "", 1)
         path = path[1:] if path.startswith("/") else path
-        
+        #This block exists because of an incompatibility between urlparse.urljoin and urllib.parse.urljoin
+        #This incompatibility results in http(s):// -> http(s):/ if the proc spec occurs in the middle of the url.
         try:
             resolver_check = verify_url_regex.match(path)
             if resolver_check: 

--- a/apigateway/utils.py
+++ b/apigateway/utils.py
@@ -4,6 +4,7 @@ from email.message import EmailMessage
 from functools import wraps
 from typing import Tuple
 from urllib.parse import urljoin
+import re
 
 import jsondiff as jd
 import requests
@@ -253,6 +254,8 @@ class ProxyView(View):
         """
         path = request.full_path.replace(self._deploy_path, "", 1)
         path = path[1:] if path.startswith("/") else path
+        verify_url_regex = re.compile(r"^([12]\d\d\d[A-Za-z&\.]{5}[A-Za-z0-9\.]{9}[A-Z\.]/verify_url\:http[s]?\://.*)")
+        if verify_url_regex.match(path): return str(self._remote_base_url)+"/"+str(path)
         return urljoin(self._remote_base_url, path)
 
 


### PR DESCRIPTION
There was a subtle change in `urljoin` between `python 2` and `python 3` when proc specs are mid-url that resulted in urls that used to be joined to form 
```
http://resolver-service/2016nsf....1557792F/verify_url:http://dx.doi.org/10.1523/ENEURO.0220-17.2017
```

now being interpreted as
```
http://resolver-service/2016nsf....1557792F/verify_url:http:/dx.doi.org/10.1523/ENEURO.0220-17.2017
```

To remedy this, we have added a regex that catches those specific urls and handles them differently.