### PR TITLE
Add access modality header + tests

### DIFF
--- a/apigateway/services.py
+++ b/apigateway/services.py
@@ -83,6 +83,8 @@ class GatewayService:
 class AuthService(GatewayService):
     """A class that provides authentication services for the API Gateway."""
 
+    MODALITY_HEADER = "X-Access-Modality"
+
     def __init__(self, name: str = "AUTH_SERVICE"):
         """Initializes the AuthService.
 
@@ -104,7 +106,7 @@ class AuthService(GatewayService):
         self._register_hooks(app)
 
     def _register_hooks(self, app: Flask):
-        """Registers hooks that manipulates the headers of the request.
+        """Registers hooks that manipulate the headers of the request.
 
         Args:
             app (Flask): The Flask application to register the hooks with.
@@ -112,24 +114,36 @@ class AuthService(GatewayService):
 
         @app.before_request
         def before_request_hook():
-            """Adds the X-api-uid header to the request if the user is authenticated with a session cookie."""
+            """Adds the X-api-uid and X-Access-Modality headers to the request if the user is authenticated with a session cookie."""
             headers = Headers(request.headers.items())
+
+            # Stop clients from spoofing modality header
+            headers.pop(AuthService.MODALITY_HEADER, None)
+
             if current_user.is_authenticated:
                 headers.add_header("X-api-uid", current_user.id)
+
+                if not current_user.is_anonymous_bootstrap_user:
+                    g.access_modality = "ui"
+                    headers[AuthService.MODALITY_HEADER] = "ui"
+
             elif "X-api-uid" in request.headers:
                 headers.remove("X-api-uid")
 
             request.headers = headers
 
-        def _token_authenticated(sender, token: OAuth2Token = None, **kwargs):
-            """Adds the X-api-uid header to the request if the user is authenticated with an auth token"""
+        token_authenticated.connect(self._token_authenticated, weak=False)
 
-            if token.user:
-                headers = Headers(request.headers.items())
-                headers.add_header("X-api-uid", token.user.id)
-                request.headers = headers
+    def _token_authenticated(self, sender, token: OAuth2Token = None, **kwargs):
+        """Adds the X-api-uid and X-Access-Modality headers for token-authenticated requests."""
+        if token is None or not token.user:
+            return
 
-        token_authenticated.connect(_token_authenticated, weak=False)
+        headers = Headers(request.headers.items())
+        headers.add_header("X-api-uid", token.user.id)
+        headers[AuthService.MODALITY_HEADER] = g.get("access_modality") or "api"
+
+        request.headers = headers
 
     def load_client(self, client_id: str) -> Tuple[OAuth2Client, OAuth2Token]:
         """Loads the OAuth2Client and OAuth2Token for the given client_id.

--- a/apigateway/tests/test_services.py
+++ b/apigateway/tests/test_services.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, call
 
 import pytest
-from flask import request
+from flask import g, request
 
 from apigateway.exceptions import ValidationError
 from apigateway.models import OAuth2Client, OAuth2Token, User
@@ -123,6 +123,131 @@ class TestAuthService:
                 func()
 
             assert "X-api-uid" not in request.headers
+
+    def test_modality_header_ui_real_session(self, app, mock_regular_user):
+        @app.route("/test_modality_ui")
+        def view_modality_ui():
+            pass
+
+        with app.test_request_context("/test_modality_ui"):
+            # Manually call before_request functions
+            for func in app.before_request_funcs[None]:
+                func()
+
+            assert request.headers["X-Access-Modality"] == "ui"
+            assert len(request.headers.getlist("X-Access-Modality")) == 1
+
+    def test_modality_header_anon_bootstrap_session_not_ui(self, app, mock_anon_user):
+        # An anonymous bootstrap session is authenticated but NOT a real user.
+        mock_anon_user.is_authenticated = True
+
+        @app.route("/test_modality_anon")
+        def view_modality_anon():
+            pass
+
+        with app.test_request_context("/test_modality_anon"):
+            for func in app.before_request_funcs[None]:
+                func()
+
+            assert "X-Access-Modality" not in request.headers
+            # Existing behavior preserved: X-api-uid is still set for the anonymous session.
+            assert "X-api-uid" in request.headers
+
+    def test_modality_header_stripped_unauthenticated(self, app):
+        @app.route("/test_modality_stripped")
+        def view_modality_stripped():
+            pass
+
+        with app.test_request_context(
+            "/test_modality_stripped",
+            headers={"X-Access-Modality": "evil"},
+        ):
+            for func in app.before_request_funcs[None]:
+                func()
+
+            assert "X-Access-Modality" not in request.headers
+
+    def test_modality_header_api_token_any_client(self, app, mock_regular_user, mock_client):
+        mock_regular_user.is_authenticated = False
+        mock_client.client_name = "ADS API client"
+        mock_token = MagicMock(user=mock_regular_user, client=mock_client)
+
+        with app.test_request_context("/test_modality_api"):
+            g.pop("access_modality", None)  # no session verdict for token-only path
+            app.auth_service._token_authenticated(sender=None, token=mock_token)
+
+            assert request.headers["X-Access-Modality"] == "api"
+            assert len(request.headers.getlist("X-Access-Modality")) == 1
+
+    def test_modality_header_api_token_bb_client_name(self, app, mock_regular_user, mock_client):
+        mock_regular_user.is_authenticated = False
+        mock_client.client_name = "BB client"
+        mock_token = MagicMock(user=mock_regular_user, client=mock_client)
+
+        with app.test_request_context("/test_modality_bb"):
+            g.pop("access_modality", None)  # no session verdict for token-only path
+            app.auth_service._token_authenticated(sender=None, token=mock_token)
+
+            assert request.headers["X-Access-Modality"] == "api"
+            assert len(request.headers.getlist("X-Access-Modality")) == 1
+
+    def test_modality_header_session_overrides_token(self, app, mock_regular_user, mock_client):
+        mock_client.client_name = "ADS API client"
+        mock_token = MagicMock(user=mock_regular_user, client=mock_client)
+
+        @app.route("/test_modality_session_wins")
+        def view_modality_session_wins():
+            pass
+
+        with app.test_request_context("/test_modality_session_wins"):
+            for func in app.before_request_funcs[None]:
+                func()
+            app.auth_service._token_authenticated(sender=None, token=mock_token)
+
+            assert request.headers["X-Access-Modality"] == "ui"
+            assert len(request.headers.getlist("X-Access-Modality")) == 1
+
+    def test_modality_header_spoof_cannot_override_session(self, app, mock_regular_user):
+        @app.route("/test_modality_spoof_session")
+        def view_modality_spoof_session():
+            pass
+
+        with app.test_request_context(
+            "/test_modality_spoof_session",
+            headers={"X-Access-Modality": "api"},
+        ):
+            for func in app.before_request_funcs[None]:
+                func()
+
+            assert request.headers["X-Access-Modality"] == "ui"
+            assert len(request.headers.getlist("X-Access-Modality")) == 1
+
+    def test_modality_header_spoof_cannot_override_token(self, app, mock_regular_user, mock_client):
+        mock_regular_user.is_authenticated = False
+        mock_client.client_name = "ADS API client"
+        mock_token = MagicMock(user=mock_regular_user, client=mock_client)
+
+        @app.route("/test_modality_spoof_token")
+        def view_modality_spoof_token():
+            pass
+
+        with app.test_request_context(
+            "/test_modality_spoof_token",
+            headers={"X-Access-Modality": "ui"},
+        ):
+            g.pop("access_modality", None)  # token-only: no leaked session verdict
+            for func in app.before_request_funcs[None]:
+                func()
+            app.auth_service._token_authenticated(sender=None, token=mock_token)
+
+            assert request.headers["X-Access-Modality"] == "api"
+            assert len(request.headers.getlist("X-Access-Modality")) == 1
+
+    def test_modality_header_token_none_no_crash(self, app):
+        with app.test_request_context("/test_modality_none"):
+            app.auth_service._token_authenticated(sender=None, token=None)
+
+            assert "X-Access-Modality" not in request.headers
 
 
 class TestProxyService:


### PR DESCRIPTION
# What?

Adds a header, `X-Access-Modality`, that is forwarded to downstream services.

# Why?

Due to changes in publisher agreements, UI & API users can each see different content. This change enables downstream services to adapt their behavior according to the user's modality.